### PR TITLE
Add tox configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ pip-wheel-metadata/
 .eggs/
 build/
 dist/
+.tox
 
 # System specific files
 

--- a/README.md
+++ b/README.md
@@ -149,9 +149,14 @@ pre-commit install
 
 # Run all pre-commit checks (CI will also run this).
 pre-commit run --all
+```
 
-# run tests
-pytest
+Tests can be run with `tox`, which creats self-contained environments
+for all commands, by using:
+
+```shell
+pip install tox
+tox
 ```
 
 Releases are created on [GitHub](https://github.com/related-sciences/nxontology/releases).

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,31 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist =
+  mypy
+
+
+[testenv]
+commands =
+    pytest
+description = Run the tests with pytest.
+
+[testenv:mypy]
+skip_install = true
+deps =
+    mypy
+commands =
+    mypy nxontology/
+description = Run the mypy tool to check static typing on the project.
+
+[testenv:pre-commit]
+skip_install = true
+deps =
+    pre-commit
+commands =
+    pre-commit run -a
+usedevelop = true
+description = Run the pre-commit tool

--- a/tox.ini
+++ b/tox.ini
@@ -5,12 +5,13 @@
 
 [tox]
 envlist =
-  mypy
-
+    py
 
 [testenv]
 commands =
     pytest
+extras =
+    dev
 description = Run the tests with pytest.
 
 [testenv:mypy]
@@ -18,14 +19,5 @@ skip_install = true
 deps =
     mypy
 commands =
-    mypy nxontology/
+    mypy --install-types --non-interactive nxontology/
 description = Run the mypy tool to check static typing on the project.
-
-[testenv:pre-commit]
-skip_install = true
-deps =
-    pre-commit
-commands =
-    pre-commit run -a
-usedevelop = true
-description = Run the pre-commit tool


### PR DESCRIPTION
This pull request adds a `tox.ini` configuration file to wrap some common commands with `tox`. This is a more python-specific tool that's like `make`. It also takes care of running all commands inside their own virtual environments as well as installing relevent dependencies, so it makes it much easier for potential users (or more specifically, potential contributors) to run testing and code quality assurance commands.

In my projects, I also use tox to run `mypy`, `black`, `flake8`, and several other QA tools. It also makes the github actions configurations much more simple! Here's an example https://github.com/bioregistry/bioregistry/blob/main/tox.ini