### PR TITLE
multidigraph_to_digraph transitive reduction option

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Counter({'is a': 71509,
          'regulates': 3216,
          'negatively regulates': 2768,
          'positively regulates': 2756})
->>> go_digraph = multidigraph_to_digraph(go_multidigraph)
+>>> go_digraph = multidigraph_to_digraph(go_multidigraph, reduce=True)
 >>> go_nxo = NXOntology(go_digraph)
 >>> # Notice the similarity increases due to the full set of edges
 >>> round(go_nxo.similarity("GO:0042552", "GO:0022008").lin, 3)

--- a/nxontology/imports.py
+++ b/nxontology/imports.py
@@ -157,7 +157,7 @@ def multidigraph_to_digraph(
     then the MultiDiGraph is first filtered for edges with that key (relationship type).
 
     If reduce is True, perform a transitive reduction on DiGraph to remove redundant relationships
-    --- i.e. those that are already captured by a more specific relationship.
+    --- i.e. those that are already captured by a more specific ancestral path.
     The default is reduce=False since the reduction can be a computationally expensive step.
     """
     logging.info(f"Received MultiDiGraph with {graph.number_of_edges():,} edges.")

--- a/nxontology/imports.py
+++ b/nxontology/imports.py
@@ -156,8 +156,9 @@ def multidigraph_to_digraph(
     When rel_types is None, all relationship types are preserved. If rel_types is defined,
     then the MultiDiGraph is first filtered for edges with that key (relationship type).
 
-    If reduce is True, perform a transitive reduction on DiGraph to remove redundant relationships
-    --- i.e. those that are already captured by a more specific ancestral path.
+    If reduce is True, perform a transitive reduction on the DiGraph
+    to produce a minimum equivalent graph that removes redundant relationships
+    — i.e. those that are already captured by a more specific ancestral path.
     The default is reduce=False since the reduction can be a computationally expensive step.
     """
     logging.info(f"Received MultiDiGraph with {graph.number_of_edges():,} edges.")

--- a/nxontology/tests/imports_test.py
+++ b/nxontology/tests/imports_test.py
@@ -90,3 +90,11 @@ def test_read_gene_ontology():
         == "http://release.geneontology.org/2021-02-01/ontology/go-basic.json.gz"
     )
     assert "regulates" in nxo.graph["GO:0006310"]["GO:0000018"]["rel_types"]
+    # Transitive reduction should remove this edge
+    # from "defense response to insect" to "negative regulation of defense response to insect"
+    # since it is redundant with a more specific ancestral path.
+    # https://github.com/related-sciences/nxontology/pull/16
+    assert not nxo.graph.has_edge("GO:0002213", "GO:1900366")
+    # GO:0002213 --> GO:2000068 --> GO:1900366 is more specific
+    assert nxo.graph.has_edge("GO:0002213", "GO:2000068")
+    assert nxo.graph.has_edge("GO:2000068", "GO:1900366")


### PR DESCRIPTION
background information at https://twitter.com/larsjuhljensen/status/1450188835032375300

Ontologies such as GO can be reduced to minimum equivalent graph when collapsing multiple relationship types into a single relationship type DiGraph.